### PR TITLE
chore: allow gosec to fail

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,6 +176,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    env:
+      GO111MODULE: on
 
     steps:
     - name: Checkout code
@@ -198,7 +200,7 @@ jobs:
     - name: Run Gosec Security Scanner
       uses: securego/gosec@master
       with:
-        args: '-fmt sarif -out gosec-results.sarif ./...'
+        args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
 
     - name: Upload Gosec scan results
       uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
For now, do not break build, if gosec fails or detects issues.