### PR TITLE
chore: try to fix build-push-action & gh-release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -251,7 +251,7 @@ jobs:
         fi
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: releases/*
         body: |


### PR DESCRIPTION
Try to push artefacts using default GITHUB_TOKEN according to the documentation:

- [docker/login-action](https://github.com/docker/login-action?tab=readme-ov-file#github-container-registry)
- [softprops/action-gh-release](https://github.com/softprops/action-gh-release)

Also remove trailing whitespace
