### PR TITLE
chore: prefix image name with ghcr.io

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   GO_VERSION: '1.24'
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   test:
@@ -149,7 +148,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.IMAGE_NAME }}
+        images: ghcr.io/${{ github.repository }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr


### PR DESCRIPTION
Prevents build-push-action to push to dockerhub.