### PR TITLE
fix: exclude Docker cache artifacts from release download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
     - name: Download all artifacts
       uses: actions/download-artifact@v4
       with:
+        pattern: release-*
         path: ./artifacts
 
     - name: Prepare release assets


### PR DESCRIPTION
The create-release job was failing because it tried to download all artifacts including Docker buildx cache artifacts that sometimes fail to download. Updated to only download release-* artifacts which are the binary packages needed for GitHub releases.

Fixes artifact download error: "Unable to download and extract artifact: Artifact download failed after 5 retries"
