### PR TITLE
chore: skip ci-cd tasks when creating a new tag

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,7 +3,6 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main, develop ]
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Run only release tasks when createin a new tag.
